### PR TITLE
feat: deb and pip version pinning in package xml [sc-4323]

### DIFF
--- a/src/rosdep2/catkin_support.py
+++ b/src/rosdep2/catkin_support.py
@@ -90,7 +90,7 @@ def resolve_for_os(rosdep_key, view, installer, os_name, os_version):
     default_os_installer = ctx.get_default_os_installer_key(os_name)
     inst_key, rule = d.get_rule_for_platform(os_name, os_version, os_installers, default_os_installer)
     assert inst_key in os_installers
-    return installer.resolve(rule)
+    return installer.resolve({}, rule)
 
 
 def update_rosdep():

--- a/src/rosdep2/installers.py
+++ b/src/rosdep2/installers.py
@@ -278,8 +278,9 @@ class Installer(object):
         """
         return []  # Default return empty list
 
-    def resolve(self, rosdep_args_dict):
+    def resolve(self, rosdep, rosdep_args_dict):
         """
+        :param rosdep: rosdep key (catkin_pkg.package.Dependency object) to resolve
         :param rosdep_args_dict: argument dictionary to the rosdep rule for this package manager
         :returns: [resolutions].  resolved objects should be printable to a user, but are otherwise opaque.
         """
@@ -336,7 +337,7 @@ class PackageManagerInstaller(Installer):
         """
         return (self.sudo_command.split() if self.as_root else []) + cmd
 
-    def resolve(self, rosdep_args):
+    def resolve(self, rosdep, rosdep_args):
         """
         See :meth:`Installer.resolve()`
         """

--- a/src/rosdep2/lookup.py
+++ b/src/rosdep2/lookup.py
@@ -34,6 +34,8 @@ import yaml
 
 from collections import defaultdict
 
+from catkin_pkg.package import Dependency
+
 from rospkg import RosPack, RosStack, ResourceNotFound
 
 from .core import RosdepInternalError, InvalidData, rd_debug
@@ -414,7 +416,7 @@ class RosdepLookup(object):
                             if depend_rosdep_key in depend_graph:
                                 continue
                             installer_key, resolution, more_dependencies = \
-                                self.resolve(depend_rosdep_key, resource_name, installer_context)
+                                self.resolve(Dependency(depend_rosdep_key), resource_name, installer_context)
                             dependencies.extend(more_dependencies)
                             depend_graph[depend_rosdep_key]['installer_key'] = installer_key
                             depend_graph[depend_rosdep_key]['install_keys'] = list(resolution)

--- a/src/rosdep2/lookup.py
+++ b/src/rosdep2/lookup.py
@@ -229,10 +229,11 @@ class RosdepView(object):
                 db[dep_name].reverse_merge(dep_data, update_entry.origin, verbose=verbose)
 
 
-def prune_catkin_packages(rosdep_keys, verbose=False):
+def prune_catkin_packages(rosdeps, verbose=False):
     workspace_pkgs = catkin_packages.get_workspace_packages()
     if not workspace_pkgs:
-        return rosdep_keys
+        return rosdeps
+    rosdep_keys = [d.name for d in rosdeps]
     for i, rosdep_key in reversed(list(enumerate(rosdep_keys))):
         if rosdep_key in workspace_pkgs:
             # If workspace packages listed (--catkin-workspace)
@@ -242,13 +243,14 @@ def prune_catkin_packages(rosdep_keys, verbose=False):
                 print("rosdep key '{0}'".format(rosdep_key) +
                       ' is in the catkin workspace, skipping.',
                       file=sys.stderr)
-            del rosdep_keys[i]
-    return rosdep_keys
+            del rosdeps[i]
+    return rosdeps
 
 
-def prune_skipped_packages(rosdep_keys, skipped_keys, verbose=False):
+def prune_skipped_packages(rosdeps, skipped_keys, verbose=False):
     if not skipped_keys:
-        return rosdep_keys
+        return rosdeps
+    rosdep_keys = [d.name for d in rosdeps]
     for i, rosdep_key in reversed(list(enumerate(rosdep_keys))):
         if rosdep_key in skipped_keys:
             # If the key is in the list of keys to explicitly skip, skip it
@@ -256,8 +258,8 @@ def prune_skipped_packages(rosdep_keys, skipped_keys, verbose=False):
                 print("rosdep key '{0}'".format(rosdep_key) +
                       ' was listed in the skipped packages, skipping.',
                       file=sys.stderr)
-            del rosdep_keys[i]
-    return rosdep_keys
+            del rosdeps[i]
+    return rosdeps
 
 
 class RosdepLookup(object):
@@ -323,7 +325,7 @@ class RosdepLookup(object):
 
         :returns: list of package names that require rosdep, ``[str]``
         """
-        return [k for k in self.loader.get_loadable_resources() if rosdep_name in self.get_rosdeps(k, implicit=False)]
+        return [k for k in self.loader.get_loadable_resources() if rosdep_name in [d.name for d in self.get_rosdeps(k, implicit=False)]]
 
     @staticmethod
     def create_from_rospkg(rospack=None, rosstack=None,
@@ -393,15 +395,16 @@ class RosdepLookup(object):
         # TODO: resolutions dictionary should be replaced with resolution model instead of mapping (undefined) keys.
         for resource_name in resources:
             try:
-                rosdep_keys = self.get_rosdeps(resource_name, implicit=implicit)
+                rosdeps = self.get_rosdeps(resource_name, implicit=implicit)
                 if self.verbose:
-                    print('resolve_all: resource [%s] requires rosdep keys [%s]' % (resource_name, ', '.join(rosdep_keys)), file=sys.stderr)
-                rosdep_keys = prune_catkin_packages(rosdep_keys, self.verbose)
-                rosdep_keys = prune_skipped_packages(rosdep_keys, self.skipped_keys, self.verbose)
-                for rosdep_key in rosdep_keys:
+                    print('resolve_all: resource [%s] requires rosdep keys [%s]' % (resource_name, ', '.join([d.name for d in rosdeps])), file=sys.stderr)
+                rosdeps = prune_catkin_packages(rosdeps, self.verbose)
+                rosdeps = prune_skipped_packages(rosdeps, self.skipped_keys, self.verbose)
+                for rosdep in rosdeps:
                     try:
                         installer_key, resolution, dependencies = \
-                            self.resolve(rosdep_key, resource_name, installer_context)
+                            self.resolve(rosdep, resource_name, installer_context)
+                        rosdep_key = rosdep.name
                         depend_graph[rosdep_key]['installer_key'] = installer_key
                         depend_graph[rosdep_key]['install_keys'] = list(resolution)
                         depend_graph[rosdep_key]['dependencies'] = list(dependencies)
@@ -433,13 +436,13 @@ class RosdepLookup(object):
 
         return resolutions_flat, errors
 
-    def resolve(self, rosdep_key, resource_name, installer_context):
+    def resolve(self, rosdep, resource_name, installer_context):
         """
         Resolve a :class:`RosdepDefinition` for a particular
         os/version spec.
 
         :param resource_name: resource (e.g. ROS package) to resolve key within
-        :param rosdep_key: rosdep key to resolve
+        :param rosdeps: rosdep key (catkin_pkg.package.Dependency object) to resolve
         :param os_name: OS name to use for resolution
         :param os_version: OS name to use for resolution
 
@@ -453,6 +456,7 @@ class RosdepLookup(object):
         :raises: :exc:`ResolutionError` If *rosdep_key* cannot be resolved for *resource_name* in *installer_context*
         :raises: :exc:`rospkg.ResourceNotFound` if *resource_name* cannot be located
         """
+        rosdep_key = rosdep.name
         os_name, os_version = installer_context.get_os_name_and_version()
 
         view = self.get_rosdep_view_for_resource(resource_name)
@@ -492,7 +496,7 @@ class RosdepLookup(object):
             installer = installer_context.get_installer(installer_key)
         except KeyError:
             raise ResolutionError(rosdep_key, definition.data, os_name, os_version, 'Unsupported installer [%s]' % (installer_key))
-        resolution = installer.resolve(rosdep_args_dict)
+        resolution = installer.resolve(rosdep, rosdep_args_dict)
         dependencies = installer.get_depends(rosdep_args_dict)
 
         # cache value

--- a/src/rosdep2/main.py
+++ b/src/rosdep2/main.py
@@ -670,7 +670,7 @@ def command_keys(lookup, packages, options):
     rosdep_keys = get_keys(lookup, packages, options.recursive)
     prune_catkin_packages(rosdep_keys, options.verbose)
     _print_lookup_errors(lookup)
-    print('\n'.join(rosdep_keys))
+    print('\n'.join([d.name for d in rosdep_keys]))
 
 
 def get_keys(lookup, packages, recursive):

--- a/src/rosdep2/platforms/debian.py
+++ b/src/rosdep2/platforms/debian.py
@@ -30,6 +30,7 @@
 from __future__ import print_function
 import subprocess
 import sys
+from rosdep2 import InvalidData
 
 from rospkg.os_detect import (
     OS_DEBIAN,
@@ -40,7 +41,7 @@ from rospkg.os_detect import (
     OS_POP,
     OS_ZORIN,
     OsDetect,
-    read_os_release
+    read_os_release,
 )
 from .pip import PIP_INSTALLER
 from .gem import GEM_INSTALLER
@@ -50,7 +51,7 @@ from ..installers import PackageManagerInstaller
 from ..shell_utils import read_stdout
 
 # apt package manager key
-APT_INSTALLER = 'apt'
+APT_INSTALLER = "apt"
 
 
 def register_installers(context):
@@ -84,8 +85,10 @@ def register_linaro(context):
     # an override force ubuntu.
     (os_name, os_version) = context.get_os_name_and_version()
     if os_name == OS_LINARO and not context.os_override:
-        print('rosdep detected OS: [%s] aliasing it to: [%s]' %
-              (OS_LINARO, OS_UBUNTU), file=sys.stderr)
+        print(
+            "rosdep detected OS: [%s] aliasing it to: [%s]" % (OS_LINARO, OS_UBUNTU),
+            file=sys.stderr,
+        )
         context.set_os_override(OS_UBUNTU, context.os_detect.get_codename())
 
 
@@ -94,8 +97,11 @@ def register_elementary(context):
     # not set as an override force ubuntu.
     (os_name, os_version) = context.get_os_name_and_version()
     if os_name == OS_ELEMENTARY and not context.os_override:
-        print('rosdep detected OS: [%s] aliasing it to: [%s]' %
-              (OS_ELEMENTARY, OS_UBUNTU), file=sys.stderr)
+        print(
+            "rosdep detected OS: [%s] aliasing it to: [%s]"
+            % (OS_ELEMENTARY, OS_UBUNTU),
+            file=sys.stderr,
+        )
         context.set_os_override(OS_UBUNTU, context.os_detect.get_codename())
 
 
@@ -104,11 +110,15 @@ def register_mx(context):
     # not set as an override, force Debian.
     (os_name, os_version) = context.get_os_name_and_version()
     if os_name == OS_MX and not context.os_override:
-        print('rosdep detected OS: [%s] aliasing it to: [%s]' %
-              (OS_MX, OS_DEBIAN), file=sys.stderr)
+        print(
+            "rosdep detected OS: [%s] aliasing it to: [%s]" % (OS_MX, OS_DEBIAN),
+            file=sys.stderr,
+        )
         release_info = read_os_release()
         version = read_os_release()["VERSION"]
-        context.set_os_override(OS_DEBIAN, version[version.find("(") + 1:version.find(")")])
+        context.set_os_override(
+            OS_DEBIAN, version[version.find("(") + 1 : version.find(")")]
+        )
 
 
 def register_pop(context):
@@ -116,8 +126,10 @@ def register_pop(context):
     # not set as an override force ubuntu.
     (os_name, os_version) = context.get_os_name_and_version()
     if os_name == OS_POP and not context.os_override:
-        print('rosdep detected OS: [%s] aliasing it to: [%s]' %
-              (OS_POP, OS_UBUNTU), file=sys.stderr)
+        print(
+            "rosdep detected OS: [%s] aliasing it to: [%s]" % (OS_POP, OS_UBUNTU),
+            file=sys.stderr,
+        )
         context.set_os_override(OS_UBUNTU, context.os_detect.get_codename())
 
 
@@ -126,8 +138,10 @@ def register_zorin(context):
     # not set as an override force ubuntu.
     (os_name, os_version) = context.get_os_name_and_version()
     if os_name == OS_ZORIN and not context.os_override:
-        print('rosdep detected OS: [%s] aliasing it to: [%s]' %
-              (OS_ZORIN, OS_UBUNTU), file=sys.stderr)
+        print(
+            "rosdep detected OS: [%s] aliasing it to: [%s]" % (OS_ZORIN, OS_UBUNTU),
+            file=sys.stderr,
+        )
         context.set_os_override(OS_UBUNTU, context.os_detect.get_codename())
 
 
@@ -149,7 +163,7 @@ def _read_apt_cache_showpkg(packages, exec_fn=None):
     second, boolean, parameter.
     """
 
-    cmd = ['apt-cache', 'showpkg'] + packages
+    cmd = ["apt-cache", "showpkg"] + packages
     if exec_fn is None:
         exec_fn = read_stdout
 
@@ -160,7 +174,7 @@ def _read_apt_cache_showpkg(packages, exec_fn=None):
     for p in packages:
         last_start = starts[-1] if len(starts) > 0 else 0
         try:
-            starts.append(std_out.index('Package: %s' % p, last_start))
+            starts.append(std_out.index("Package: %s" % p, last_start))
         except ValueError:
             notfound.add(p)
     starts.append(None)
@@ -170,9 +184,9 @@ def _read_apt_cache_showpkg(packages, exec_fn=None):
             yield p, False, None
             continue
         start = starts.pop(0)
-        lines = iter(std_out[start:starts[0]])
+        lines = iter(std_out[start : starts[0]])
 
-        header = 'Package: %s' % p
+        header = "Package: %s" % p
         # proceed to Package header
         try:
             while next(lines) != header:
@@ -182,14 +196,14 @@ def _read_apt_cache_showpkg(packages, exec_fn=None):
 
         # proceed to versions section
         try:
-            while next(lines) != 'Versions: ':
+            while next(lines) != "Versions: ":
                 pass
         except StopIteration:
             pass
 
         # virtual packages don't have versions
         try:
-            if next(lines) != '':
+            if next(lines) != "":
                 yield p, False, None
                 continue
         except StopIteration:
@@ -197,12 +211,12 @@ def _read_apt_cache_showpkg(packages, exec_fn=None):
 
         # proceed to reserve provides section
         try:
-            while next(lines) != 'Reverse Provides: ':
+            while next(lines) != "Reverse Provides: ":
                 pass
         except StopIteration:
             pass
 
-        pr = [line.split(' ', 2)[0] for line in lines]
+        pr = [line.split(" ", 2)[0] for line in lines]
         if pr:
             yield p, True, pr
         else:
@@ -224,27 +238,29 @@ def dpkg_detect(pkgs, exec_fn=None):
     # This is a map `package name -> package name optionally with version`.
     version_lock_map = {}
     for p in pkgs:
-        if '=' in p:
-            version_lock_map[p.split('=')[0]] = p
+        if "=" in p:
+            version_lock_map[p.split("=")[0]] = p
         else:
             version_lock_map[p] = p
-    cmd = ['dpkg-query', '-W', '-f=\'${Package} ${Status}\n\'']
+    cmd = ["dpkg-query", "-W", "-f='${Package} ${Status}\n'"]
     cmd.extend(version_lock_map.keys())
 
     if exec_fn is None:
         exec_fn = read_stdout
     std_out, std_err = exec_fn(cmd, True)
-    std_out = std_out.replace('\'', '')
-    pkg_list = std_out.split('\n')
+    std_out = std_out.replace("'", "")
+    pkg_list = std_out.split("\n")
     for pkg in pkg_list:
         pkg_row = pkg.split()
-        if len(pkg_row) == 4 and (pkg_row[3] == 'installed'):
+        if len(pkg_row) == 4 and (pkg_row[3] == "installed"):
             ret_list.append(pkg_row[0])
     installed_packages = [version_lock_map[r] for r in ret_list]
 
     # now for the remaining packages check, whether they are installed as
     # virtual packages
-    remaining = _read_apt_cache_showpkg(list(p for p in pkgs if p not in installed_packages))
+    remaining = _read_apt_cache_showpkg(
+        list(p for p in pkgs if p not in installed_packages)
+    )
     virtual = [n for (n, v, pr) in remaining if v and len(dpkg_detect(pr)) > 0]
 
     return installed_packages + virtual
@@ -276,10 +292,48 @@ class AptInstaller(PackageManagerInstaller):
     def __init__(self):
         super(AptInstaller, self).__init__(dpkg_detect)
 
+    def resolve(self, rosdep, rosdep_args):
+        """
+        See :meth:`Installer.resolve()`
+        """
+        packages = None
+        if type(rosdep_args) == dict:
+            packages = rosdep_args.get("packages", [])
+            if isinstance(packages, str):
+                packages = packages.split()
+        elif isinstance(rosdep_args, str):
+            packages = rosdep_args.split(" ")
+        elif type(rosdep_args) == list:
+            packages = rosdep_args
+        else:
+            raise InvalidData("Invalid rosdep args: %s" % (rosdep_args))
+
+        if rosdep.version_eq:
+            for i, package in list(enumerate(packages)):
+                packages[i] = package + "=" + rosdep.version_eq
+        if rosdep.version_gte:
+            raise InvalidData(
+                "version_gte not supported for debian package: %s" % (rosdep)
+            )
+        if rosdep.version_lte:
+            raise InvalidData(
+                "version_lte not supported for debian package: %s" % (rosdep)
+            )
+        if rosdep.version_gt:
+            raise InvalidData(
+                "version_gt not supported for debian package: %s" % (rosdep)
+            )
+        if rosdep.version_lt:
+            raise InvalidData(
+                "version_lt not supported for debian package: %s" % (rosdep)
+            )
+
+        return packages
+
     def get_version_strings(self):
-        output = subprocess.check_output(['apt-get', '--version'])
-        version = output.splitlines()[0].split(b' ')[1].decode()
-        return ['apt-get {}'.format(version)]
+        output = subprocess.check_output(["apt-get", "--version"])
+        version = output.splitlines()[0].split(b" ")[1].decode()
+        return ["apt-get {}".format(version)]
 
     def _get_install_commands_for_package(self, base_cmd, package_or_list):
         def pkg_command(p):
@@ -290,14 +344,20 @@ class AptInstaller(PackageManagerInstaller):
         else:
             return pkg_command(package_or_list)
 
-    def get_install_command(self, resolved, interactive=True, reinstall=False, quiet=False):
+    def get_install_command(
+        self, resolved, interactive=True, reinstall=False, quiet=False
+    ):
         packages = self.get_packages_to_install(resolved, reinstall=reinstall)
+        print(packages)
         if not packages:
             return []
-        base_cmd = ['apt-get', 'install']
+        base_cmd = ["apt-get", "install"]
         if not interactive:
-            base_cmd.append('-y')
+            base_cmd.append("-y")
         if quiet:
-            base_cmd.append('-qq')
+            base_cmd.append("-qq")
 
-        return [self._get_install_commands_for_package(base_cmd, p) for p in _iterate_packages(packages, reinstall)]
+        return [
+            self._get_install_commands_for_package(base_cmd, p)
+            for p in _iterate_packages(packages, reinstall)
+        ]

--- a/src/rosdep2/platforms/osx.py
+++ b/src/rosdep2/platforms/osx.py
@@ -281,7 +281,7 @@ class HomebrewInstaller(PackageManagerInstaller):
         except OSError:
             return ['Homebrew not-found']
 
-    def resolve(self, rosdep_args):
+    def resolve(self, rosdep, rosdep_args):
         """
         See :meth:`Installer.resolve()`
         """
@@ -318,7 +318,7 @@ class HomebrewInstaller(PackageManagerInstaller):
 
             return options
 
-        packages = super(HomebrewInstaller, self).resolve(rosdep_args)
+        packages = super(HomebrewInstaller, self).resolve(rosdep, rosdep_args)
         resolution = []
         if packages:
             options = []

--- a/src/rosdep2/platforms/source.py
+++ b/src/rosdep2/platforms/source.py
@@ -201,7 +201,7 @@ class SourceInstaller(PackageManagerInstaller):
         super(SourceInstaller, self).__init__(source_detect, supports_depends=True)
         self._rdmanifest_cache = {}
 
-    def resolve(self, rosdep_args):
+    def resolve(self, rosdep, rosdep_args):
         """
         :raises: :exc:`InvalidData` If format invalid or unable
           to retrieve rdmanifests.
@@ -246,7 +246,7 @@ class SourceInstaller(PackageManagerInstaller):
 
     def get_depends(self, rosdep_args):
         deps = rosdep_args.get('depends', [])
-        for r in self.resolve(rosdep_args):
+        for r in self.resolve({}, rosdep_args):
             deps.extend(r.dependencies)
         return deps
 

--- a/src/rosdep2/rospkg_loader.py
+++ b/src/rosdep2/rospkg_loader.py
@@ -136,19 +136,40 @@ class RosPkgLoader(RosdepLoader):
 
         :raises: :exc:`rospkg.ResourceNotFound` if *resource_name* cannot be found.
         """
-
         if resource_name in self.get_catkin_paths():
             pkg = catkin_pkg.package.parse_package(self.get_catkin_paths()[resource_name])
             pkg.evaluate_conditions(os.environ)
             deps = pkg.build_depends + pkg.buildtool_depends + pkg.run_depends + pkg.test_depends + pkg.buildtool_export_depends
-            return [d.name for d in deps if d.evaluated_condition]
+            return [d for d in deps if d.evaluated_condition]
         elif resource_name in self.get_loadable_resources():
-            rosdeps = set(self._rospack.get_rosdeps(resource_name, implicit=False))
+            # expand 'self._rospack.get_rosdeps(resource_name, implicit=implicit)' to return Dependency
+            def rospack_get_rosdeps(rospack, package, implicit=implicit):
+                if implicit:
+                    return rospack_implicit_rosdeps(rospack, package)
+                else:
+                    m = rospack.get_manifest(package)
+                    return m.rosdeps
+
+            def rospack_implicit_rosdeps(rospack, package):
+                # set the key before recursive call to prevent infinite case
+                s = set()
+                # take the union of all dependencies
+                packages = rospack.get_depends(package, implicit=True)
+                for p in packages:
+                    s.update(rospack_get_rosdeps(rospack, p, implicit=False))
+                # add in our own deps
+                m = rospack.get_manifest(package)
+                s.update(m.rosdeps)
+                # cache the return value as a list
+                s = list(s)
+                return s
+
+            rosdeps = set(rospack_get_rosdeps(self._rospack, resource_name, implicit=False))
             if implicit:
                 # This resource is a manifest.xml, but it might depend on things with a package.xml
                 # Make sure they get a chance to evaluate conditions
                 for dep in self._rospack.get_depends(resource_name):
-                    rosdeps = rosdeps.union(set(self.get_rosdeps(dep, implicit=True)))
+                    rosdeps = rosdeps.union(set(rospack_get_rosdeps(self._rospack, dep, implicit=True)))
             return list(rosdeps)
         elif resource_name in self._rosstack.list():
             # stacks currently do not have rosdeps of their own, implicit or otherwise

--- a/test/test_rosdep_installers.py
+++ b/test/test_rosdep_installers.py
@@ -294,6 +294,7 @@ def test_InstallerContext_os_installers():
 
 
 def test_Installer_tripwire():
+    from catkin_pkg.package import Dependency
     from rosdep2.installers import Installer
     try:
         Installer().is_installed('foo')
@@ -306,7 +307,7 @@ def test_Installer_tripwire():
     except NotImplementedError:
         pass
     try:
-        Installer().resolve({})
+        Installer().resolve(Dependency('null'), {})
         assert False
     except NotImplementedError:
         pass
@@ -341,26 +342,27 @@ def test_PackageManagerInstaller():
 
 
 def test_PackageManagerInstaller_resolve():
+    from catkin_pkg.package import Dependency
     from rosdep2 import InvalidData
     from rosdep2.installers import PackageManagerInstaller
 
     installer = PackageManagerInstaller(detect_fn_all)
-    assert ['baz'] == installer.resolve(dict(depends=['foo', 'bar'], packages=['baz']))
-    assert ['baz', 'bar'] == installer.resolve(dict(packages=['baz', 'bar']))
+    assert ['baz'] == installer.resolve(Dependency('baz'), dict(depends=['foo', 'bar'], packages=['baz']))
+    assert ['baz', 'bar'] == installer.resolve(Dependency('baz'), dict(packages=['baz', 'bar']))
 
     # test string logic
-    assert ['baz'] == installer.resolve(dict(depends=['foo', 'bar'], packages='baz'))
-    assert ['baz', 'bar'] == installer.resolve(dict(packages='baz bar'))
-    assert ['baz'] == installer.resolve('baz')
-    assert ['baz', 'bar'] == installer.resolve('baz bar')
+    assert ['baz'] == installer.resolve(Dependency('baz'), dict(depends=['foo', 'bar'], packages='baz'))
+    assert ['baz', 'bar'] == installer.resolve(Dependency('baz'), dict(packages='baz bar'))
+    assert ['baz'] == installer.resolve(Dependency('baz'), 'baz')
+    assert ['baz', 'bar'] == installer.resolve(Dependency('baz'), 'baz bar')
 
     # test list logic
-    assert ['baz'] == installer.resolve(['baz'])
-    assert ['baz', 'bar'] == installer.resolve(['baz', 'bar'])
+    assert ['baz'] == installer.resolve(Dependency('baz'), ['baz'])
+    assert ['baz', 'bar'] == installer.resolve(Dependency('baz'), ['baz', 'bar'])
 
     # test invalid data
     try:
-        installer.resolve(0)
+        installer.resolve(Dependency('baz'), 0)
         assert False, 'should have raised'
     except InvalidData:
         pass

--- a/test/test_rosdep_lookup.py
+++ b/test/test_rosdep_lookup.py
@@ -308,25 +308,26 @@ def test_RosdepLookup_get_rosdeps():
         pass
 
     print(lookup.get_rosdeps('stack1_p1'))
-    assert set(lookup.get_rosdeps('stack1_p1')) == set(['stack1_dep1', 'stack1_p1_dep1', 'stack1_p1_dep2'])
-    assert set(lookup.get_rosdeps('stack1_p1', implicit=False)) == set(['stack1_dep1', 'stack1_p1_dep1', 'stack1_p1_dep2'])
+    assert set([d.name for d in lookup.get_rosdeps('stack1_p1')]) == set(['stack1_dep1', 'stack1_p1_dep1', 'stack1_p1_dep2'])
+    assert set([d.name for d in lookup.get_rosdeps('stack1_p1', implicit=False)]) == set(['stack1_dep1', 'stack1_p1_dep1', 'stack1_p1_dep2'])
 
     print(lookup.get_rosdeps('stack1_p2'))
-    assert set(lookup.get_rosdeps('stack1_p2', implicit=False)) == set(['stack1_dep1', 'stack1_dep2', 'stack1_p2_dep1']), set(lookup.get_rosdeps('stack1_p2'))
-    assert set(lookup.get_rosdeps('stack1_p2', implicit=True)) == set(['stack1_dep1', 'stack1_dep2', 'stack1_p1_dep1', 'stack1_p1_dep2', 'stack1_p2_dep1']), set(lookup.get_rosdeps('stack1_p2'))
+    assert set([d.name for d in lookup.get_rosdeps('stack1_p2', implicit=False)]) == set(['stack1_dep1', 'stack1_dep2', 'stack1_p2_dep1']), set(lookup.get_rosdeps('stack1_p2'))
+    assert set([d.name for d in lookup.get_rosdeps('stack1_p2', implicit=True)]) == \
+        set(['stack1_dep1', 'stack1_dep2', 'stack1_p1_dep1', 'stack1_p1_dep2', 'stack1_p2_dep1']), set([d.name for d in lookup.get_rosdeps('stack1_p2')])
 
     # catkin
     print(lookup.get_rosdeps('simple_catkin_package'))
-    assert set(lookup.get_rosdeps('simple_catkin_package')) == set(['catkin', 'testboost'])
-    assert set(lookup.get_rosdeps('simple_catkin_package', implicit=False)) == set(['catkin', 'testboost'])
+    assert set([d.name for d in lookup.get_rosdeps('simple_catkin_package')]) == set(['catkin', 'testboost'])
+    assert set([d.name for d in lookup.get_rosdeps('simple_catkin_package', implicit=False)]) == set(['catkin', 'testboost'])
 
     print(lookup.get_rosdeps('another_catkin_package'))
-    assert set(lookup.get_rosdeps('another_catkin_package')) == set(['catkin', 'simple_catkin_package'])  # implicit deps won't get included
-    assert set(lookup.get_rosdeps('another_catkin_package', implicit=False)) == set(['catkin', 'simple_catkin_package'])
+    assert set([d.name for d in lookup.get_rosdeps('another_catkin_package')]) == set(['catkin', 'simple_catkin_package'])  # implicit deps won't get included
+    assert set([d.name for d in lookup.get_rosdeps('another_catkin_package', implicit=False)]) == set(['catkin', 'simple_catkin_package'])
 
     print(lookup.get_rosdeps('metapackage_with_deps'))
-    assert set(lookup.get_rosdeps('metapackage_with_deps')) == set(['catkin', 'simple_catkin_package', 'another_catkin_package'])  # implicit deps won't get included
-    assert set(lookup.get_rosdeps('metapackage_with_deps', implicit=False)) == set(['catkin', 'simple_catkin_package', 'another_catkin_package'])
+    assert set([d.name for d in lookup.get_rosdeps('metapackage_with_deps')]) == set(['catkin', 'simple_catkin_package', 'another_catkin_package'])  # implicit deps won't get included
+    assert set([d.name for d in lookup.get_rosdeps('metapackage_with_deps', implicit=False)]) == set(['catkin', 'simple_catkin_package', 'another_catkin_package'])
 
 
 def test_RosdepLookup_get_resources_that_need():
@@ -483,6 +484,7 @@ def test_RosdepLookup_resolve_all_errors():
 
 
 def test_RosdepLookup_resolve_errors():
+    from catkin_pkg.package import Dependency
     from rosdep2.installers import InstallerContext
     from rosdep2.lookup import RosdepLookup, ResolutionError
     rospack, rosstack = get_test_rospkgs()
@@ -495,19 +497,20 @@ def test_RosdepLookup_resolve_errors():
     installer_context.set_os_override('ubuntu', 'lucid')
 
     try:
-        lookup.resolve('testtinyxml', 'rospack_fake', installer_context)
+        lookup.resolve(Dependency('testtinyxml'), 'rospack_fake', installer_context)
         assert False, 'should have raised'
     except ResolutionError as e:
         assert 'Unsupported OS' in str(e), str(e)
 
     try:
-        lookup.resolve('fakedep', 'rospack_fake', installer_context)
+        lookup.resolve(Dependency('fakedep'), 'rospack_fake', installer_context)
         assert False, 'should have raised'
     except ResolutionError as e:
         assert 'Cannot locate rosdep definition' in str(e), str(e)
 
 
 def test_RosdepLookup_resolve():
+    from catkin_pkg.package import Dependency
     from rosdep2 import create_default_installer_context
     from rosdep2.lookup import RosdepLookup
     rospack, rosstack = get_test_rospkgs()
@@ -520,17 +523,17 @@ def test_RosdepLookup_resolve():
 
     # repeat for caching
     for count in range(0, 2):
-        installer_key, resolution, dependencies = lookup.resolve('testtinyxml', 'rospack_fake', installer_context)
+        installer_key, resolution, dependencies = lookup.resolve(Dependency('testtinyxml'), 'rospack_fake', installer_context)
         assert 'apt' == installer_key
         assert ['libtinyxml-dev'] == resolution
         assert [] == dependencies
 
-        installer_key, resolution, dependencies = lookup.resolve('testboost', 'roscpp_fake', installer_context)
+        installer_key, resolution, dependencies = lookup.resolve(Dependency('testboost'), 'roscpp_fake', installer_context)
         assert 'apt' == installer_key
         assert ['libboost1.40-all-dev'] == resolution
         assert [] == dependencies
 
-        installer_key, resolution, dependencies = lookup.resolve('testlibtool', 'roscpp_fake', installer_context)
+        installer_key, resolution, dependencies = lookup.resolve(Dependency('testlibtool'), 'roscpp_fake', installer_context)
         assert 'apt' == installer_key
         assert set(['libtool', 'libltdl-dev']) == set(resolution)
         assert [] == dependencies

--- a/test/test_rosdep_pip.py
+++ b/test/test_rosdep_pip.py
@@ -67,6 +67,48 @@ def test_PipInstaller_get_depends():
     assert ['foo'] == installer.get_depends(dict(depends=['foo']))
 
 
+def test_PackageManagerInstaller_resolve():
+    from rosdep2 import InvalidData
+    from rosdep2.platforms.pip import PipInstaller
+    from catkin_pkg.package import Dependency
+
+    installer = PipInstaller()
+    assert ['baz'] == installer.resolve(Dependency('baz'), dict(depends=['foo', 'bar'], packages=['baz']))
+    assert ['baz', 'bar'] == installer.resolve(Dependency('baz'), dict(packages=['baz', 'bar']))
+
+    # test string logic
+    assert ['baz'] == installer.resolve(Dependency('baz'), dict(depends=['foo', 'bar'], packages='baz'))
+    assert ['baz', 'bar'] == installer.resolve(Dependency('baz'), dict(packages='baz bar'))
+    assert ['baz'] == installer.resolve(Dependency('baz'), 'baz')
+    assert ['baz', 'bar'] == installer.resolve(Dependency('baz'), 'baz bar')
+
+    # test list logic
+    assert ['baz'] == installer.resolve(Dependency('baz'), ['baz'])
+    assert ['baz', 'bar'] == installer.resolve(Dependency('baz'), ['baz', 'bar'])
+
+    # version_eq
+    assert ["'baz==1.0'"] == installer.resolve(Dependency('baz', version_eq='1.0'), dict(depends=['foo', 'bar'], packages=['baz']))
+    assert ["'baz==1.0'", "'bar==1.0'"] == installer.resolve(Dependency('baz', version_eq='1.0'), dict(packages=['baz', 'bar']))
+    # version_gte
+    assert ["'baz>=1.0'"] == installer.resolve(Dependency('baz', version_gte='1.0'), dict(depends=['foo', 'bar'], packages=['baz']))
+    assert ["'baz>=1.0'", "'bar>=1.0'"] == installer.resolve(Dependency('baz', version_gte='1.0'), dict(packages=['baz', 'bar']))
+    # version_lte
+    assert ["'baz<=1.0'"] == installer.resolve(Dependency('baz', version_lte='1.0'), dict(depends=['foo', 'bar'], packages=['baz']))
+    assert ["'baz<=1.0'", "'bar<=1.0'"] == installer.resolve(Dependency('baz', version_lte='1.0'), dict(packages=['baz', 'bar']))
+    # version_gt
+    assert ["'baz>1.0'"] == installer.resolve(Dependency('baz', version_gt='1.0'), dict(depends=['foo', 'bar'], packages=['baz']))
+    assert ["'baz>1.0'", "'bar>1.0'"] == installer.resolve(Dependency('baz', version_gt='1.0'), dict(packages=['baz', 'bar']))
+    # version_lt
+    assert ["'baz<1.0'"] == installer.resolve(Dependency('baz', version_lt='1.0'), dict(depends=['foo', 'bar'], packages=['baz']))
+    assert ["'baz<1.0'", "'bar<1.0'"] == installer.resolve(Dependency('baz', version_lt='1.0'), dict(packages=['baz', 'bar']))
+    # test invalid data
+    try:
+        installer.resolve({}, 0)
+        assert False, 'should have raised'
+    except InvalidData:
+        pass
+
+
 def test_PipInstaller():
     from rosdep2 import InstallFailed
     from rosdep2.platforms.pip import PipInstaller

--- a/test/test_rosdep_pip.py
+++ b/test/test_rosdep_pip.py
@@ -87,20 +87,20 @@ def test_PackageManagerInstaller_resolve():
     assert ['baz', 'bar'] == installer.resolve(Dependency('baz'), ['baz', 'bar'])
 
     # version_eq
-    assert ["'baz==1.0'"] == installer.resolve(Dependency('baz', version_eq='1.0'), dict(depends=['foo', 'bar'], packages=['baz']))
-    assert ["'baz==1.0'", "'bar==1.0'"] == installer.resolve(Dependency('baz', version_eq='1.0'), dict(packages=['baz', 'bar']))
+    assert ['baz==1.0'] == installer.resolve(Dependency('baz', version_eq='1.0'), dict(depends=['foo', 'bar'], packages=['baz']))
+    assert ['baz==1.0', 'bar==1.0'] == installer.resolve(Dependency('baz', version_eq='1.0'), dict(packages=['baz', 'bar']))
     # version_gte
-    assert ["'baz>=1.0'"] == installer.resolve(Dependency('baz', version_gte='1.0'), dict(depends=['foo', 'bar'], packages=['baz']))
-    assert ["'baz>=1.0'", "'bar>=1.0'"] == installer.resolve(Dependency('baz', version_gte='1.0'), dict(packages=['baz', 'bar']))
+    assert ['baz>=1.0'] == installer.resolve(Dependency('baz', version_gte='1.0'), dict(depends=['foo', 'bar'], packages=['baz']))
+    assert ['baz>=1.0', 'bar>=1.0'] == installer.resolve(Dependency('baz', version_gte='1.0'), dict(packages=['baz', 'bar']))
     # version_lte
-    assert ["'baz<=1.0'"] == installer.resolve(Dependency('baz', version_lte='1.0'), dict(depends=['foo', 'bar'], packages=['baz']))
-    assert ["'baz<=1.0'", "'bar<=1.0'"] == installer.resolve(Dependency('baz', version_lte='1.0'), dict(packages=['baz', 'bar']))
+    assert ['baz<=1.0'] == installer.resolve(Dependency('baz', version_lte='1.0'), dict(depends=['foo', 'bar'], packages=['baz']))
+    assert ['baz<=1.0', 'bar<=1.0'] == installer.resolve(Dependency('baz', version_lte='1.0'), dict(packages=['baz', 'bar']))
     # version_gt
-    assert ["'baz>1.0'"] == installer.resolve(Dependency('baz', version_gt='1.0'), dict(depends=['foo', 'bar'], packages=['baz']))
-    assert ["'baz>1.0'", "'bar>1.0'"] == installer.resolve(Dependency('baz', version_gt='1.0'), dict(packages=['baz', 'bar']))
+    assert ['baz>1.0'] == installer.resolve(Dependency('baz', version_gt='1.0'), dict(depends=['foo', 'bar'], packages=['baz']))
+    assert ['baz>1.0', 'bar>1.0'] == installer.resolve(Dependency('baz', version_gt='1.0'), dict(packages=['baz', 'bar']))
     # version_lt
-    assert ["'baz<1.0'"] == installer.resolve(Dependency('baz', version_lt='1.0'), dict(depends=['foo', 'bar'], packages=['baz']))
-    assert ["'baz<1.0'", "'bar<1.0'"] == installer.resolve(Dependency('baz', version_lt='1.0'), dict(packages=['baz', 'bar']))
+    assert ['baz<1.0'] == installer.resolve(Dependency('baz', version_lt='1.0'), dict(depends=['foo', 'bar'], packages=['baz']))
+    assert ['baz<1.0', 'bar<1.0'] == installer.resolve(Dependency('baz', version_lt='1.0'), dict(packages=['baz', 'bar']))
     # test invalid data
     try:
         installer.resolve({}, 0)

--- a/test/test_rosdep_source.py
+++ b/test/test_rosdep_source.py
@@ -191,6 +191,7 @@ exit 0
 
 
 def test_SourceInstaller_resolve():
+    from catkin_pkg.package import Dependency
     from rosdep2.platforms.source import SourceInstaller, InvalidData
     test_dir = get_test_dir()
 
@@ -200,16 +201,16 @@ def test_SourceInstaller_resolve():
 
     installer = SourceInstaller()
     try:
-        installer.resolve({})
+        installer.resolve(Dependency('null'), {})
         assert False, 'should have raised'
     except InvalidData:
         pass
     try:
-        installer.resolve(dict(uri=url, md5sum=md5sum_bad))
+        installer.resolve(Dependency('null'), dict(uri=url, md5sum=md5sum_bad))
         assert False, 'should have raised'
     except InvalidData:
         pass
-    resolved = installer.resolve(dict(uri=url, md5sum=md5sum_good))
+    resolved = installer.resolve(Dependency('null'), dict(uri=url, md5sum=md5sum_good))
 
     assert type(resolved) == list
     assert len(resolved) == 1
@@ -222,7 +223,7 @@ def test_SourceInstaller_resolve():
     assert resolved.check_presence_command == rep122_check_presence_command
 
     # test again to activate caching
-    resolved = installer.resolve(dict(uri=url, md5sum=md5sum_good))
+    resolved = installer.resolve(Dependency('null'), dict(uri=url, md5sum=md5sum_good))
     assert type(resolved) == list, 'Cache should also return a list'
     assert len(resolved) == 1
     resolved = resolved[0]


### PR DESCRIPTION
* Resolves merge conflicts between `k-okada`'s branch and master
* Unit tests fixed
* Add `version_eq` support to debian packages

Example usage:
```xml
<?xml version="1.0"?>
<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
<package format="3">
  <name>example</name>
  <version>1.0.10</version>
  <description>trigger</description>
  <maintainer email="david.revay@greenroomrobotics.com">David Revay</maintainer>
  <license>Apache 2</license>

  <buildtool_depend>ament_cmake_auto</buildtool_depend>

  <build_depend>rosidl_default_generators</build_depend>

  <depend>std_msgs</depend>
  <depend version_eq="1.1.1">package_publish_test</depend>
  <depend>usb-utils</depend>
  <depend version_gte="1.1.1">python3-aiohttp-cors-pip</depend>
  <depend version_eq="2.0.0">python3-ipdb-pip</depend>
  <depend>python3-av-pip</depend>
</package>
```
Running `rosdep install -i --from-paths . -s --reinstall` with this fork (and Greenroom's rosdistro list) we get the following output:
 ```
 #[apt] Installation commands:
  sudo -H apt-get install package_publish_test=1.1.1
  sudo -H apt-get install usbutils
#[pip] Installation commands:
  sudo -H pip3 install -I aiohttp-cors>=1.1.1
  sudo -H pip3 install -I ipdb==2.0.0
  sudo -H pip3 install -I -U av
  ```
  
  Supplying any version constraint other than `version_eq` to a debian package will result in an error (as apt-get only supports version_eq)