### PR TITLE
fix: allow downgrades

### DIFF
--- a/src/rosdep2/platforms/debian.py
+++ b/src/rosdep2/platforms/debian.py
@@ -364,7 +364,7 @@ class AptInstaller(PackageManagerInstaller):
         packages = self.get_packages_to_install(resolved, reinstall=reinstall)
         if not packages:
             return []
-        base_cmd = ["apt-get", "install"]
+        base_cmd = ["apt-get", "install", "--allow-downgrades"]
         if not interactive:
             base_cmd.append("-y")
         if quiet:


### PR DESCRIPTION
Resolves errors such as:

```
#0 73.48 The following packages will be DOWNGRADED:
#0 73.48   ros-humble-geolocation-msgs
#0 73.48 0 upgraded, 0 newly installed, 1 downgraded, 0 to remove and 43 not upgraded.
#0 73.48 E: Packages were downgraded and -y was used without --allow-downgrades.
#0 73.48 ERROR: the following rosdeps failed to install
#0 73.48   apt: command [sudo -H apt-get install -y ros-humble-geolocation-msgs=1.2.2-*] failed
#0 73.48 executing command [sudo -H apt-get install -y vulcanexus-humble-dds-router]
#0 73.48 executing command [sudo -H apt-get install -y ros-humble-rosbridge-suite]
#0 73.48 executing command [sudo -H apt-get install -y ros-humble-mcap-vendor]
#0 73.48 executing command [sudo -H apt-get install -y ros-humble-rosbag2-storage-mcap]
#0 73.48 executing command [sudo -H apt-get install -y ros-humble-ros2trace]
#0 73.48 executing command [sudo -H apt-get install -y ros-humble-ros2trace-analysis]
#0 73.48 executing command [sudo -H apt-get install -y ros-humble-tracetools-launch]
#0 73.48 executing command [sudo -H apt-get install -y ros-humble-tracetools-test]
#0 73.48 executing command [sudo -H apt-get install -y lttng-tools]
#0 73.48 executing command [sudo -H apt-get install -y can-utils]
#0 73.48 executing command [sudo -H apt-get install -y tshark]
#0 73.48 executing command [sudo -H apt-get install -y ros-humble-launch-ext=1.3.0-*]
#0 73.48 executing command [sudo -H apt-get install -y ros-humble-maritime-control-msgs=1.6.0-*]
#0 73.48 executing command [sudo -H apt-get install -y ros-humble-ais-msgs=1.0.1-*]
#0 73.48 executing command [sudo -H apt-get install -y ros-humble-perception-msgs=1.3.1-*]
#0 73.48 executing command [sudo -H apt-get install -y ros-humble-geofence-msgs=1.1.0-*]
#0 73.48 executing command [sudo -H apt-get install -y ros-humble-waypoint-msgs=1.1.0-*]
#0 73.48 executing command [sudo -H apt-get install -y ros-humble-notification-msgs=1.2.0-*]
#0 73.48 executing command [sudo -H apt-get install -y ros-humble-network-monitoring-interfaces=1.3.0-*]
#0 73.48 executing command [sudo -H apt-get install -y ros-humble-geolocation-msgs=1.2.2-*]
#0 73.52 Command 'rosdep install -y --rosdistro humble --from-paths /home/package_manifests/src/gama_bringup -i' returned non-zero exit status 1.
#0 73.52 Error: Run failed
```